### PR TITLE
Fix: MIDI velocity was playing even when "RecordNoteVelocity" option was off

### DIFF
--- a/Source/Input/PianoInput.cs
+++ b/Source/Input/PianoInput.cs
@@ -182,7 +182,8 @@ namespace WaveTracker {
             note = Math.Clamp(note, 12, 131);
             if (!midiNotes.Contains(note)) {
                 midiNotes.Add(note);
-                OnNoteOnEvent(note, (int)Math.Ceiling(velocity / 127f * 99), true);
+                var noteVelocity = App.Settings.MIDI.RecordNoteVelocity ? (int?)Math.Ceiling(velocity / 127f * 99) : null;
+                OnNoteOnEvent(note, noteVelocity, true);
             }
         }
         /// <summary>

--- a/Source/UI/PatternEditor.cs
+++ b/Source/UI/PatternEditor.cs
@@ -1622,7 +1622,7 @@ namespace WaveTracker.UI {
                 if (!InstrumentMask) {
                     CurrentPattern[cursorPosition.Row, cursorPosition.Channel, CellType.Instrument] = (byte)App.InstrumentBank.CurrentInstrumentIndex;
                 }
-                if (volume.HasValue && App.Settings.MIDI.RecordNoteVelocity) {
+                if (volume.HasValue) {
                     CurrentPattern[cursorPosition.Row, cursorPosition.Channel, CellType.Volume] = (byte)volume.Value;
                 }
                 MoveToRow(cursorPosition.Row + InputStep);


### PR DESCRIPTION
It was not recording it, but it was playing it when pressed a key.