### PR TITLE
[BUG] Fix preview channel playing wrong wave

### DIFF
--- a/Source/Tracker/Playback.cs
+++ b/Source/Tracker/Playback.cs
@@ -69,7 +69,6 @@ namespace WaveTracker.Tracker {
             IsPlaying = true;
             tickCounter = 0;
             ChannelManager.Reset();
-            ChannelManager.PreviewChannel.Reset();
             position.Frame = App.PatternEditor.cursorPosition.Frame;
             position.Row = 0;
             if (App.PatternEditor.FollowMode && !AudioEngine.IsRendering) {

--- a/Source/UI/WaveEditor.cs
+++ b/Source/UI/WaveEditor.cs
@@ -175,8 +175,8 @@ namespace WaveTracker.UI {
                 }
 
                 //Temp fix for PreviewChannel wave being changed when song is played
-                if(ChannelManager.PreviewChannel.WaveIndex != WaveBank.currentWaveID) {
-                    ChannelManager.PreviewChannel.SetWave(WaveBank.currentWaveID);
+                if(ChannelManager.PreviewChannel.WaveIndex != id) {
+                    ChannelManager.PreviewChannel.SetWave(id);
                 }
 
                 resampleDropdown.Value = (int)CurrentWave.resamplingMode;

--- a/Source/UI/WaveEditor.cs
+++ b/Source/UI/WaveEditor.cs
@@ -174,6 +174,11 @@ namespace WaveTracker.UI {
                     ChannelManager.PreviewChannel.SetWave(WaveBank.currentWaveID);
                 }
 
+                //Temp fix for PreviewChannel wave being changed when song is played
+                if(ChannelManager.PreviewChannel.WaveIndex != WaveBank.currentWaveID) {
+                    ChannelManager.PreviewChannel.SetWave(WaveBank.currentWaveID);
+                }
+
                 resampleDropdown.Value = (int)CurrentWave.resamplingMode;
                 if (startcooldown > 0) {
                     waveText.Text = CurrentWave.ToNumberString();


### PR DESCRIPTION
- Resolves #59 

### The Bug
Whenever the song is played, paused or stopped, all the channels are reset by `ChannelManager.Reset()`. This forces the preview channel's wave index to be set back to 0. If the wave editor is open, this results in the wave editor playing the 0th wave in the wave bank.

### The Fix
Within the `Update()` function in the `WaveEditor` class, by checking if the preview channels wave ID is not the same as the wave editor ID, the wave editor will then update the preview channels wave ID