### PR TITLE
Two fixes in TrimSilence

### DIFF
--- a/WaveTracker/Source/App.cs
+++ b/WaveTracker/Source/App.cs
@@ -247,18 +247,18 @@ namespace WaveTracker {
             SDL_MaximizeWindow(Window.Handle);
 
             CurrentModule = new WTModule();
-            WaveBank = new WaveBank(510, 18 + MENUSTRIP_HEIGHT);
+            WaveBank = new WaveBank(697, 18 + MENUSTRIP_HEIGHT);
             ChannelManager.Initialize(WTModule.MAX_CHANNEL_COUNT);
-            PatternEditor = new PatternEditor(0, 184 + MENUSTRIP_HEIGHT);
+            PatternEditor = new PatternEditor(0, 95 + MENUSTRIP_HEIGHT);
             InstrumentBank = new InstrumentBank(790, 152 + MENUSTRIP_HEIGHT);
             InstrumentEditor = new InstrumentEditor();
             Visualizer = new Visualizer();
             Dialogs.Initialize();
-            EditSettings = new EditSettings(312, 18 + MENUSTRIP_HEIGHT);
+            EditSettings = new EditSettings(312, 395 + MENUSTRIP_HEIGHT);
             Toolbar = new Toolbar(2, 0 + MENUSTRIP_HEIGHT);
             WaveEditor = new WaveEditor();
-            FramesPanel = new FramesPanel(2, 106 + MENUSTRIP_HEIGHT, 504, 42);
-            ModulePanel = new ModulePanel(2, 18 + MENUSTRIP_HEIGHT);
+            FramesPanel = new FramesPanel(2, 18 + MENUSTRIP_HEIGHT, 604, 42);
+            ModulePanel = new ModulePanel(2, 395 + MENUSTRIP_HEIGHT);
             AudioEngine.Initialize();
 
             IsFixedTimeStep = false;

--- a/WaveTracker/Source/SettingsProfile.cs
+++ b/WaveTracker/Source/SettingsProfile.cs
@@ -31,7 +31,7 @@ namespace WaveTracker {
 
         }
         public class CategoryGeneral {
-            public int ScreenScale { get; set; } = 2;
+            public int ScreenScale { get; set; } = 3;
             public bool UseHighResolutionText { get; set; } = false;
 
             public int OscilloscopeMode { get; set; } = 2;
@@ -43,14 +43,14 @@ namespace WaveTracker {
         public class CategoryFiles {
             public string DefaultTicksPerRow { get; set; } = "4";
             public int DefaultRowsPerFrame { get; set; } = 64;
-            public int DefaultNumberOfChannels { get; set; } = 12;
+            public int DefaultNumberOfChannels { get; set; } = 8;
             public string DefaultAuthorName { get; set; } = "";
             public int DefaultRowPrimaryHighlight { get; set; } = 16;
             public int DefaultRowSecondaryHighlight { get; set; } = 4;
         }
 
         public class CategoryAppearance {
-            public ColorTheme Theme { get; set; } = ColorTheme.Default;
+            public ColorTheme Theme { get; set; } = ColorTheme.OpenMPT;
             public void Validate() {
                 Theme.Validate();
             }
@@ -58,12 +58,12 @@ namespace WaveTracker {
 
         public class CategoryPatternEditor {
             public bool ShowRowNumbersInHex { get; set; } = false;
-            public bool ShowNoteOffAndReleaseAsText { get; set; } = false;
+            public bool ShowNoteOffAndReleaseAsText { get; set; } = true;
             public bool FadeVolumeColumn { get; set; } = true;
             public bool ShowPreviousNextFrames { get; set; } = true;
             public bool IgnoreStepWhenMoving { get; set; } = true;
             public MoveToNextRowBehavior StepAfterNumericInput { get; set; } = MoveToNextRowBehavior.Always;
-            public bool WrapCursorHorizontally { get; set; } = true;
+            public bool WrapCursorHorizontally { get; set; } = false;
             public bool KeyRepeat { get; set; } = true;
             public int PageJumpAmount { get; set; } = 4;
             public bool RestoreChannelState { get; set; } = true;

--- a/WaveTracker/Source/SettingsProfile.cs
+++ b/WaveTracker/Source/SettingsProfile.cs
@@ -167,6 +167,7 @@ namespace WaveTracker {
                 {"Edit\\Backspace", new KeyboardShortcut(Keys.Back) },
                 {"Edit\\Insert", new KeyboardShortcut(Keys.Insert) },
                 {"Edit\\Delete", new KeyboardShortcut(Keys.Delete) },
+                {"Edit\\Delete row", new KeyboardShortcut(Keys.Delete, KeyModifier.Ctrl) },
                 {"Edit\\Select all", new KeyboardShortcut(Keys.A, KeyModifier.Ctrl) },
                 {"Edit\\Deselect", new KeyboardShortcut(Keys.Escape) },
 

--- a/WaveTracker/Source/Tracker/Sample.cs
+++ b/WaveTracker/Source/Tracker/Sample.cs
@@ -232,49 +232,50 @@ namespace WaveTracker.Tracker {
         }
 
         public void TrimSilence() {
-            List<short> sampleDataLeft = sampleDataL.ToList();
-            List<short> sampleDataRight = sampleDataR.ToList();
-            if (sampleDataLeft.Count > 1000) {
+            int soundStartIndex = 0;
+            int soundEndIndex = sampleDataL.Length - 1;
+
+            if (sampleDataL.Length > 1000) {
                 if (IsStereo) {
-                    for (int i = 0; i < sampleDataLeft.Count; ++i) {
-                        if (Math.Abs(sampleDataLeft[i] / (float)short.MaxValue) > 0.001f || Math.Abs(sampleDataRight[i]) > 0.001f) {
+                    for (int i = 0; i < sampleDataL.Length; ++i) {
+                        if (Math.Abs(sampleDataL[i] / (float)short.MaxValue) > 0.001f
+                            || Math.Abs(sampleDataR[i] / (float)short.MaxValue) > 0.001f) {
                             break;
                         }
 
-                        sampleDataLeft.RemoveAt(i);
-                        sampleDataRight.RemoveAt(i);
+                        soundStartIndex = i;
                     }
 
-                    for (int i = sampleDataLeft.Count - 1; i >= 0; --i) {
-                        if (Math.Abs(sampleDataLeft[i] / (float)short.MaxValue) > 0.001f || Math.Abs(sampleDataRight[i]) > 0.001f) {
+                    for (int i = sampleDataL.Length - 1; i >= 0; --i) {
+                        if (Math.Abs(sampleDataL[i] / (float)short.MaxValue) > 0.001f
+                            || Math.Abs(sampleDataR[i] / (float)short.MaxValue) > 0.001f) {
                             break;
                         }
 
-                        sampleDataLeft.RemoveAt(i);
-                        sampleDataRight.RemoveAt(i);
+                        soundEndIndex = i;
                     }
                 }
                 else {
-                    for (int i = 0; i < sampleDataLeft.Count; ++i) {
-                        if (Math.Abs(sampleDataLeft[i] / (float)short.MaxValue) > 0.001f) {
+                    for (int i = 0; i < sampleDataL.Length; ++i) {
+                        if (Math.Abs(sampleDataL[i] / (float)short.MaxValue) > 0.001f) {
                             break;
                         }
 
-                        sampleDataLeft.RemoveAt(i);
+                        soundStartIndex = i;
                     }
 
-                    for (int i = sampleDataLeft.Count - 1; i >= 0; --i) {
-                        if (Math.Abs(sampleDataLeft[i] / (float)short.MaxValue) > 0.001f) {
+                    for (int i = sampleDataL.Length - 1; i >= 0; --i) {
+                        if (Math.Abs(sampleDataL[i] / (float)short.MaxValue) > 0.001f) {
                             break;
                         }
 
-                        sampleDataLeft.RemoveAt(i);
+                        soundEndIndex = i;
                     }
                 }
             }
 
-            sampleDataL = sampleDataLeft.ToArray();
-            sampleDataR = sampleDataRight.ToArray();
+            sampleDataL = sampleDataL.Skip(soundStartIndex).Take(soundEndIndex - soundStartIndex).ToArray();
+            sampleDataR = sampleDataR.Skip(soundStartIndex).Take(soundEndIndex - soundStartIndex).ToArray();
         }
 
         public float GetMonoSample(float time, float startPercentage) {

--- a/WaveTracker/Source/Tracker/SaveLoad.cs
+++ b/WaveTracker/Source/Tracker/SaveLoad.cs
@@ -643,19 +643,13 @@ namespace WaveTracker {
                 Thread t = new Thread(() => {
                     Input.DialogStarted();
                     Input.CancelClick();
-                    // OpenFileDialog openFileDialog = new OpenFileDialog();
-                    // openFileDialog.InitialDirectory = ThemeFolderPath;
-                    // openFileDialog.CheckPathExists = true;
-                    // openFileDialog.Filter = "WaveTracker Theme (*.wttheme)|*.wttheme";
-                    // openFileDialog.Multiselect = false;
-                    // openFileDialog.Title = "Open";
-                    // openFileDialog.ValidateNames = true;
 
-                    // if (openFileDialog.ShowDialog() == DialogResult.OK) {
-                    //     ret = openFileDialog.FileName;
-                    //     didIt = true;
-                    // }
+                    NfdStatus status = Nfd.OpenDialog(out string themePath, themeDialogFilters, SaveLoad.ThemeFolderPath);
 
+                    if (status == NfdStatus.Ok) {
+                        ret = themePath;
+                        didIt = true;
+                    }
                 });
 
                 if (OperatingSystem.IsWindows())
@@ -665,7 +659,6 @@ namespace WaveTracker {
                 t.Start();
                 t.Join();
                 filepath = ret;
-
             }
             return didIt;
         }

--- a/WaveTracker/Source/UI/ConfigurationDialog.cs
+++ b/WaveTracker/Source/UI/ConfigurationDialog.cs
@@ -310,7 +310,7 @@ namespace WaveTracker.UI {
             }
         }
 
-        #region Page definitions
+        // Page definitions
         public class Page : Clickable {
             protected Dictionary<string, ConfigurationOption> options;
             protected int ypos = 2;
@@ -509,10 +509,10 @@ namespace WaveTracker.UI {
                 colorList.SaveDictionaryInto(theme.Colors);
             }
         }
-        #endregion
+        
     }
 
-    #region Option definitions
+    // Option definitions
     public class ConfigurationOption : Clickable {
         public string Name { get; private set; }
         public string Description { get; private set; }
@@ -779,6 +779,6 @@ namespace WaveTracker.UI {
         }
 
     }
-    #endregion
+    
 
 }

--- a/WaveTracker/Source/UI/EditSettings.cs
+++ b/WaveTracker/Source/UI/EditSettings.cs
@@ -26,6 +26,8 @@ namespace WaveTracker.UI {
         }
 
         public void Update() {
+            this.y = App.WindowHeight - 95;
+
             if (App.Shortcuts["General\\Increase step"].IsPressedDown) {
                 App.PatternEditor.InputStep = Math.Clamp(App.PatternEditor.InputStep + 1, 0, 256);
             }

--- a/WaveTracker/Source/UI/Element.cs
+++ b/WaveTracker/Source/UI/Element.cs
@@ -15,7 +15,7 @@ namespace WaveTracker.UI {
         protected int GlobalX { get { return x + OffX; } }
         protected int GlobalY { get { return y + OffY; } }
 
-        public bool InFocus {
+        public virtual bool InFocus {
             get {
                 return Input.focus == null || (parent == null ? Input.focus == this : parent.InFocus || Input.focus == this);
             }

--- a/WaveTracker/Source/UI/EnvelopeEditor.cs
+++ b/WaveTracker/Source/UI/EnvelopeEditor.cs
@@ -133,7 +133,7 @@ namespace WaveTracker.UI {
                 }
 
                 // input loop/release
-                #region loop/release
+                // loop/release
                 if (Input.GetClickDown(KeyModifier.None) && currentEnvelope.IsActive) {
                     if (MouseIsInReleaseRibbon && MouseEnvelopeX >= 1 && MouseEnvelopeX < currentEnvelope.Length) {
                         currentEnvelope.ReleaseIndex = currentEnvelope.ReleaseIndex != MouseEnvelopeX - 1 ? (byte)(MouseEnvelopeX - 1) : (byte)Envelope.EMPTY_LOOP_RELEASE_INDEX;
@@ -144,7 +144,7 @@ namespace WaveTracker.UI {
                         App.CurrentModule.SetDirty();
                     }
                 }
-                #endregion
+                
             }
         }
 
@@ -385,7 +385,7 @@ namespace WaveTracker.UI {
                         s += "(" + CanvasMouseBlockClamped().X + ", " + CanvasMouseBlockClamped().Y + ")";
                     }
                     Write(s, 90, 226, UIColors.label);
-                    #region draw loop/release
+                    // draw loop/release
                     // draw release
                     if (MouseIsInReleaseRibbon && MouseEnvelopeX >= 1 && MouseEnvelopeX < currentEnvelope.Length && currentEnvelope.IsActive) {
                         DrawFlagSprite(GetXPositionOfColumn(MouseEnvelopeX) - 1, 11, new Rectangle(400, 107, 40, 9));
@@ -412,7 +412,7 @@ namespace WaveTracker.UI {
                         }
                         DrawRect(GetXPositionOfColumn(currentEnvelope.LoopIndex) - 1, 10, 1, height - 11, new Color(99, 171, 63));
                     }
-                    #endregion
+                    
                     switch (currentEnvelope.Type) {
                         case Envelope.EnvelopeType.Volume:
                         case Envelope.EnvelopeType.WaveBlend:

--- a/WaveTracker/Source/UI/FramesPanel.cs
+++ b/WaveTracker/Source/UI/FramesPanel.cs
@@ -23,12 +23,13 @@ namespace WaveTracker.UI {
             frames = new FrameButton[25];
             for (int i = 0; i < frames.Length; ++i) {
                 frames[i] = new FrameButton(i - frames.Length / 2, this);
-                frames[i].x = 54 + i * 18;
+                frames[i].x = i * 18;
                 frames[i].y = 21;
             }
         }
 
         public void Update() {
+            this.width = App.WindowWidth - 160;
             if (InFocus) {
                 foreach (FrameButton button in frames) {
                     button.Update();
@@ -81,12 +82,11 @@ namespace WaveTracker.UI {
             bDuplicateFrame.Draw();
             bMoveLeft.Draw();
             bMoveRight.Draw();
-            DrawRect(67, 11, 423, 29, new Color(32, 37, 64));
+            DrawRect(67, 11, this.width - 70, 29, new Color(32, 37, 64));
             foreach (FrameButton button in frames) {
                 button.Draw();
             }
             DrawRect(54, 11, 13, 29, new Color(223, 224, 232));
-            DrawRect(490, 11, 13, 29, new Color(223, 224, 232));
         }
     }
 }

--- a/WaveTracker/Source/UI/InstrumentBank.cs
+++ b/WaveTracker/Source/UI/InstrumentBank.cs
@@ -16,6 +16,12 @@ namespace WaveTracker.UI {
             }
         }
 
+        public override bool InFocus {
+            get {
+                return base.InFocus || App.InstrumentEditor.IsOpen;
+            }
+        }
+
         public SpriteButton bNewWave, bNewNoise, bNewSample, bRemove, bDuplicate, bMoveUp, bMoveDown, bRename;
         public SpriteButton bEdit;
         public Menu menu;

--- a/WaveTracker/Source/UI/ModulePanel.cs
+++ b/WaveTracker/Source/UI/ModulePanel.cs
@@ -29,6 +29,8 @@ namespace WaveTracker.UI {
         }
 
         public void Update() {
+            this.y = App.WindowHeight - 95;
+
             if (InFocus) {
                 title.Text = App.CurrentModule.Title;
                 title.Update();

--- a/WaveTracker/Source/UI/ModulePanel.cs
+++ b/WaveTracker/Source/UI/ModulePanel.cs
@@ -118,7 +118,7 @@ namespace WaveTracker.UI {
 
         public void DrawVolumeMeters(int px, int py, int width, int height) {
             Color grey = new Color(163, 167, 194);
-            #region draw L+R letters
+            // draw L+R letters
             DrawRect(px - 7, py, 1, 4, grey);
             DrawRect(px - 6, py + 3, 2, 1, grey);
 
@@ -127,7 +127,7 @@ namespace WaveTracker.UI {
             DrawRect(px - 6, py + height + 3, 1, 1, grey);
             DrawRect(px - 5, py + height + 2, 1, 1, grey);
             DrawRect(px - 5, py + height + 4, 1, 1, grey);
-            #endregion
+            
 
             for (int i = 0; i < Audio.AudioEngine.CurrentBuffer.GetLength(1); i++) {
                 float l = Math.Abs(Audio.AudioEngine.CurrentBuffer[0, i]);

--- a/WaveTracker/Source/UI/PatternEditor.cs
+++ b/WaveTracker/Source/UI/PatternEditor.cs
@@ -185,7 +185,7 @@ namespace WaveTracker.UI {
                 ClearHistory();
             }
             // responsive height
-            int bottomMargin = 8;
+            int bottomMargin = 100;
             if (channelScrollbar.IsVisible) {
                 height = App.WindowHeight - y - bottomMargin - channelScrollbar.height;
             }
@@ -194,7 +194,7 @@ namespace WaveTracker.UI {
             }
 
             // responsive width
-            int rightMargin = 156;
+            int rightMargin = 160;
             width = App.WindowWidth - x - rightMargin - 1;
             #region change octave
             if (App.Shortcuts["General\\Decrease octave"].IsPressedRepeat) {

--- a/WaveTracker/Source/UI/PatternEditor.cs
+++ b/WaveTracker/Source/UI/PatternEditor.cs
@@ -196,7 +196,7 @@ namespace WaveTracker.UI {
             // responsive width
             int rightMargin = 160;
             width = App.WindowWidth - x - rightMargin - 1;
-            #region change octave
+            // change octave
             if (App.Shortcuts["General\\Decrease octave"].IsPressedRepeat) {
                 CurrentOctave--;
                 PianoInput.ClearAllNotes();
@@ -212,7 +212,7 @@ namespace WaveTracker.UI {
                 }
             }
             CurrentOctave = Math.Clamp(CurrentOctave, 0, 9);
-            #endregion
+            
 
             if (Input.focus == null && !App.VisualizerMode) {
                 FirstVisibleChannel -= Input.MouseScrollWheel(KeyModifier.Alt);
@@ -252,7 +252,7 @@ namespace WaveTracker.UI {
             lastSelection.Set(App.CurrentSong, selection.min, selection.max);
             lastSelection.IsActive = selection.IsActive;
 
-            #region solo/mute channels function keys
+            // solo/mute channels function keys
             if (App.Shortcuts["General\\Toggle channel"].IsPressedDown) {
                 ChannelManager.ToggleChannel(cursorPosition.Channel);
             }
@@ -265,13 +265,13 @@ namespace WaveTracker.UI {
                     ChannelManager.SoloChannel(cursorPosition.Channel);
                 }
             }
-            #endregion
+            
 
             //////////////////////////////
             //        NAVIGATION        //
             //////////////////////////////
 
-            #region home/end navigation
+            // home/end navigation
             // On home key press
             if (Input.GetKeyRepeat(App.Shortcuts["Pattern\\Jump to top of frame"].Key, KeyModifier.None)) {
                 GoToTopOfFrame();
@@ -280,8 +280,8 @@ namespace WaveTracker.UI {
             if (Input.GetKeyRepeat(App.Shortcuts["Pattern\\Jump to bottom of frame"].Key, KeyModifier.None)) {
                 GoToBottomOfFrame();
             }
-            #endregion
-            #region moving cursor with arrow keys
+            
+            // moving cursor with arrow keys
             // On arrow keys
             if (Input.GetKeyRepeat(Keys.Left, KeyModifier.None)) {
                 CancelSelection();
@@ -319,8 +319,8 @@ namespace WaveTracker.UI {
                 CancelSelection();
                 MoveToRow(cursorPosition.Row - (App.Settings.PatternEditor.IgnoreStepWhenMoving ? 1 : InputStep));
             }
-            #endregion
-            #region navigate with mouse
+            
+            // navigate with mouse
             if (ClickedDown) {
                 CancelSelection();
             }
@@ -338,8 +338,8 @@ namespace WaveTracker.UI {
                 MoveToRow(cursorPosition.Row + App.Settings.PatternEditor.PageJumpAmount);
             }
 
-            #endregion
-            #region selection with arrow keys
+            
+            // selection with arrow keys
             if (Input.GetKeyRepeat(Keys.Left, KeyModifier.Shift)) {
                 if (!SelectionIsActive) {
                     SetSelectionStart(cursorPosition);
@@ -438,8 +438,8 @@ namespace WaveTracker.UI {
                 GoToBottomOfFrame();
                 SetSelectionEnd(cursorPosition);
             }
-            #endregion
-            #region selection with mouse
+            
+            // selection with mouse
             if (Input.GetClick(KeyModifier.None) && Input.MouseIsDragging && GlobalPointIsInBounds(Input.LastClickLocation) && MouseX < App.WindowWidth - 12 && MouseY < App.WindowHeight - 12) {
                 if (!SelectionIsActive) {
                     SetSelectionStart(GetCursorPositionFromPoint(LastClickPos.X, LastClickPos.Y));
@@ -475,28 +475,28 @@ namespace WaveTracker.UI {
                 selectionEnd.Row = CurrentPattern.GetModifiedLength() - 1;
                 selectionEnd.Column = App.CurrentSong.GetLastCursorColumnOfChannel(selectionEnd.Channel);
             }
-            #endregion
-            #region selection with CTRL-A and ESC
+            
+            // selection with CTRL-A and ESC
             if (App.Shortcuts["Edit\\Select all"].IsPressedRepeat) {
                 SelectAll();
             }
             if (App.Shortcuts["Edit\\Deselect"].IsPressedRepeat) {
                 CancelSelection();
             }
-            #endregion
+            
 
             if (!SelectionIsActive) {
                 selectionStart = selectionEnd = cursorPosition;
             }
             selection.Set(App.CurrentSong, selectionStart, selectionEnd);
 
-            #region copying selection
+            // copying selection
             if (SelectionIsActive) {
                 if (App.Shortcuts["Edit\\Copy"].IsPressedDown) {
                     CopyToClipboard();
                 }
             }
-            #endregion
+            
 
             if (App.Shortcuts["General\\Toggle edit mode"].IsPressedRepeat) {
                 ToggleEditMode();
@@ -508,7 +508,7 @@ namespace WaveTracker.UI {
             //           EDITING           //
             /////////////////////////////////
 
-            #region field input
+            // field input
             if (cursorPosition.Column == CursorColumnType.Note) {
                 // input note column
                 foreach (string pianoKeyShortcut in KeyInputs_Piano.Keys) {
@@ -719,8 +719,8 @@ namespace WaveTracker.UI {
                     }
                 }
             }
-            #endregion
-            #region scroll field modifiers
+            
+            // scroll field modifiers
             if (IsHovered) {
                 if (!SelectionIsActive) {
                     // scrolling field modifiers
@@ -842,8 +842,8 @@ namespace WaveTracker.UI {
                     }
                 }
             }
-            #endregion
-            #region backspace + insert + delete
+            
+            // backspace + insert + delete
 
             if (KeyPress(App.Shortcuts["Edit\\Backspace"])) {
                 Backspace();
@@ -858,8 +858,8 @@ namespace WaveTracker.UI {
                 Delete(true);
             }
 
-            #endregion
-            #region value increment and transposing
+            
+            // value increment and transposing
             if (App.Shortcuts["Pattern\\Transpose: note down"].IsPressedRepeat) {
                 DecreaseNote();
             }
@@ -976,8 +976,8 @@ namespace WaveTracker.UI {
                     AddToUndoHistory();
                 }
             }
-            #endregion
-            #region interpolate and reverse
+            
+            // interpolate and reverse
             if (SelectionIsActive) {
                 if (App.Shortcuts["Pattern\\Interpolate"].IsPressedRepeat) {
                     InterpolateSelection();
@@ -986,8 +986,8 @@ namespace WaveTracker.UI {
                     ReverseSelection();
                 }
             }
-            #endregion
-            #region copy/paste/cut
+            
+            // copy/paste/cut
             if (SelectionIsActive) {
                 if (App.Shortcuts["Edit\\Cut"].IsPressedRepeat) {
                     Cut();
@@ -1001,8 +1001,8 @@ namespace WaveTracker.UI {
                     PasteAndMix();
                 }
             }
-            #endregion
-            #region undo/redo
+            
+            // undo/redo
             if (App.Shortcuts["Edit\\Undo"].IsPressedRepeat) {
                 Undo();
             }
@@ -1010,23 +1010,23 @@ namespace WaveTracker.UI {
             if (App.Shortcuts["Edit\\Redo"].IsPressedRepeat) {
                 Redo();
             }
-            #endregion
-            #region alt+s replace instrument
+            
+            // alt+s replace instrument
             if (SelectionIsActive) {
                 if (App.Shortcuts["Pattern\\Replace instrument"].IsPressedDown) {
                     ReplaceInstrument();
                 }
             }
-            #endregion
-            #region alt+h humanize
+            
+            // alt+h humanize
             if (App.Shortcuts["Pattern\\Humanize volumes"].IsPressedDown) {
                 Humanize();
             }
-            #endregion
+            
 
         }
 
-        #region Draw Methods
+        // Draw Methods
         public void Draw() {
             playbackFrame = Playback.position.Frame;
             playbackRow = Playback.position.Row;
@@ -1361,9 +1361,9 @@ namespace WaveTracker.UI {
                 }
             }
         }
-        #endregion
+        
 
-        #region move cursor methods
+        // move cursor methods
 
         /// <summary>
         /// Resets the cursor position and view to the beginning of the song, and clears undo history
@@ -1467,9 +1467,9 @@ namespace WaveTracker.UI {
         private void MoveToChannel(int channel) {
             cursorPosition.MoveToChannel(channel, App.CurrentSong);
         }
-        #endregion
+        
 
-        #region selectionMethods
+        // selectionMethods
 
         /// <summary>
         /// Sets the selection start position
@@ -1531,7 +1531,7 @@ namespace WaveTracker.UI {
             }
         }
 
-        #endregion
+        
 
         public void ToggleEditMode() {
             EditMode = !EditMode;
@@ -2142,7 +2142,7 @@ namespace WaveTracker.UI {
             }
         }
 
-        #region frame methods
+        // frame methods
 
         /// <summary>
         /// Moves to the next frame in the song
@@ -2238,7 +2238,7 @@ namespace WaveTracker.UI {
             CurrentFrame.PatternIndex--;
             AddToUndoHistory();
         }
-        #endregion
+        
 
         /// <summary>
         /// Snaps the cursor position to the playback row.
@@ -2544,7 +2544,7 @@ namespace WaveTracker.UI {
             };
         }
 
-        #region Key Input Dictionaries
+        // Key Input Dictionaries
         private readonly Dictionary<string, int> KeyInputs_Piano = new Dictionary<string, int>() {
             { "Piano\\Note off", WTPattern.EVENT_NOTE_CUT },
             { "Piano\\Note release", WTPattern.EVENT_NOTE_RELEASE },
@@ -2637,6 +2637,6 @@ namespace WaveTracker.UI {
             {Keys.D9, 9},
             {Keys.NumPad9, 9},
         };
-        #endregion
+        
     }
 }

--- a/WaveTracker/Source/UI/SampleEditor.cs
+++ b/WaveTracker/Source/UI/SampleEditor.cs
@@ -57,7 +57,7 @@ namespace WaveTracker.UI {
         private CheckboxLabeled showInVisualizer;
         private int lastMouseHoverSample;
         private ScrollbarHorizontal viewportScrollbar;
-        private SpriteButton undo, redo, delete, zoomIn, zoomOut, zoomInVertical, zoomOutVertical, fadeIn, fadeOut, reverse;
+        private SpriteButton undo, redo, delete, crop, zoomIn, zoomOut, zoomInVertical, zoomOutVertical, fadeIn, fadeOut, reverse;
         private DropdownButton tools;
 
         public new bool InFocus => base.InFocus || Dialogs.currentSampleModifyDialog != null && Dialogs.currentSampleModifyDialog.InFocus;
@@ -103,6 +103,9 @@ namespace WaveTracker.UI {
             delete = new SpriteButton(buttonsX, buttonsY, 15, 15, 360, 0, this);
             delete.SetTooltip("Delete", "Delete the selected audio");
             buttonsX += 18;
+            crop = new SpriteButton(buttonsX, buttonsY, 15, 15, 360, 0, this);
+            crop.SetTooltip("Crop", "Crop to selected audio");
+            buttonsX += 18;
             zoomIn = new SpriteButton(buttonsX, buttonsY, 15, 15, 465, 0, this);
             zoomIn.SetTooltip("Zoom in (horizontal)", "Zoom into the audio view horizontally");
             buttonsX += 15;
@@ -128,6 +131,7 @@ namespace WaveTracker.UI {
             tools = new DropdownButton("Tools...", buttonsX, buttonsY, 50, this);
             tools.SetMenuItems([
                 new DropdownButton.Option("Delete", () => SelectionIsActive),
+                new DropdownButton.Option("Crop", () => SelectionIsActive),
                 new DropdownButton.Option("Fade in",() => Sample.Length > 0),
                 new DropdownButton.Option("Fade out",() => Sample.Length > 0),
                 new DropdownButton.Option("Reverse",() => Sample.Length > 0),
@@ -160,6 +164,7 @@ namespace WaveTracker.UI {
             undo.enabled = CanUndo;
             redo.enabled = CanRedo;
             delete.enabled = SelectionIsActive;
+            crop.enabled = SelectionIsActive;
             zoomIn.enabled = CanZoomIn && Sample.Length > 0;
             zoomOut.enabled = CanZoomOut && Sample.Length > 0;
             zoomInVertical.enabled = zoomLevelVertical < 50 && Sample.Length > 0;
@@ -230,6 +235,7 @@ namespace WaveTracker.UI {
                             null,
                             new SubMenu("Tools", new MenuItemBase[] {
                                 new MenuOption("Delete", Delete, SelectionIsActive),
+                                new MenuOption("Crop", Crop, SelectionIsActive),
                                 new MenuOption("Fade In", FadeIn),
                                 new MenuOption("Fade Out", FadeOut),
                                 new MenuOption("Reverse", Reverse),
@@ -315,6 +321,9 @@ namespace WaveTracker.UI {
                 if (delete.Clicked) {
                     Delete();
                 }
+                if (crop.Clicked) {
+                    Crop();
+                }
 
                 tools.Update();
                 if (tools.SelectedAnItem) {
@@ -323,30 +332,33 @@ namespace WaveTracker.UI {
                             Delete();
                             break;
                         case 1:
-                            FadeIn();
+                            Crop();
                             break;
                         case 2:
-                            FadeOut();
+                            FadeIn();
                             break;
                         case 3:
-                            Reverse();
+                            FadeOut();
                             break;
                         case 4:
-                            Invert();
+                            Reverse();
                             break;
                         case 5:
-                            Normalize();
+                            Invert();
                             break;
                         case 6:
-                            RemoveDCOffset();
+                            Normalize();
                             break;
                         case 7:
-                            MixToMono();
+                            RemoveDCOffset();
                             break;
                         case 8:
-                            OpenAmplifier();
+                            MixToMono();
                             break;
                         case 9:
+                            OpenAmplifier();
+                            break;
+                        case 10:
                             OpenBitcrusher();
                             break;
 
@@ -478,6 +490,13 @@ namespace WaveTracker.UI {
 
         private void Delete() {
             Sample.Delete(SelectionMin, SelectionMax);
+            SelectionIsActive = false;
+            AddToUndoHistory();
+        }
+
+        private void Crop() {
+            Sample.Delete(SelectionMax, Sample.Length);
+            Sample.Delete(0, SelectionMin);
             SelectionIsActive = false;
             AddToUndoHistory();
         }
@@ -617,6 +636,7 @@ namespace WaveTracker.UI {
             undo.Draw();
             redo.Draw();
             delete.Draw();
+            crop.Draw();
             zoomIn.Draw();
             zoomOut.Draw();
             zoomInVertical.Draw();

--- a/WaveTracker/Source/UI/WaveBank.cs
+++ b/WaveTracker/Source/UI/WaveBank.cs
@@ -26,6 +26,8 @@ namespace WaveTracker.UI {
         }
 
         public void Update() {
+            this.x = App.WindowWidth - 155;
+
             if (Input.focus == null) {
                 currentWaveID = -1;
             }

--- a/WaveTracker/WaveTracker.csproj
+++ b/WaveTracker/WaveTracker.csproj
@@ -61,7 +61,6 @@
     <PackageReference Include="NCalcSync" Version="5.2.10" />
     <PackageReference Include="protobuf-net" Version="3.2.30" />
     <PackageReference Include="TextCopy" Version="6.2.1" />
-    <PackageReference Include="System.Windows.Extensions" Version="8.0.0" Condition=" '$(OS)' == 'Windows_NT' " />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\WaveTracker.Midi\WaveTracker.Midi.csproj" />


### PR DESCRIPTION
Hello Sir,

This commit addresses slowness when importing bigger samples when "trim silence on import" is enabled. It was caused by list allocations and repeated memory copying - I have changed the logic to avoid this and do it only once at the end.

Also, while looking at the code I noticed a difference in the silence detection condition between the left and the right channel. I believe that the left channel condition is correct, so I applied the same approach to the right channel. Seems to work better with this change, but please double check if it is correct.

BR,
Andrzej