### PR TITLE
fix: Normalize downsample factor based on current oversampling settings

### DIFF
--- a/WaveTracker/Source/Audio/Channel.cs
+++ b/WaveTracker/Source/Audio/Channel.cs
@@ -246,7 +246,9 @@ namespace WaveTracker.Audio {
                     waveSyncAmt.patternValue = parameter;
                     break;
                 case 'X':
-                    downsampleFactor = parameter;
+                    // Normalized to x2 oversampling (base recommended value).
+                    // Compensates downsample effectiveness based on current oversampling.
+                    downsampleFactor = parameter * App.Settings.Audio.Oversampling / 2;
                     break;
                 case 'H':
                     SetFilter(Helpers.Map(parameter / 16, 0, 16, 1, 0.3f), Helpers.Map(parameter % 16, 0, 16, 1, 8));


### PR DESCRIPTION
Closes #91.

I just multiplied `downsampleFactor` by the current Oversampling setting. However, in order to avoid redundancy when `Oversampling = 2`, I divided `downsampleFactor` by 2.

Now, I noticed it's not 1:1 (meaning you will NOT get the exact same sound in Oversampling set to x8 and set to x2, but it's close enough).